### PR TITLE
add async-defun font-lock like defun

### DIFF
--- a/async-await.el
+++ b/async-await.el
@@ -200,5 +200,12 @@
        (async-await--awaiter
         (funcall (iter-lambda () ,exps))))))
 
+(defconst async-font-lock-keywords
+  '(("(\\(async-defun\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
+     (1 font-lock-keyword-face)
+     (2 font-lock-function-name-face nil t))))
+
+(font-lock-add-keywords 'emacs-lisp-mode async-font-lock-keywords)
+
 (provide 'async-await)
 ;;; async-await.el ends here


### PR DESCRIPTION
Thanks for developing such a great package!

I add `async-defun` font-lock like `defun`.
I refference `use-package` [font-lock scheme](https://github.com/jwiegley/use-package/blob/4714d73b61bdb378f6e9e3f3838cae1abbf65ea0/use-package-core.el#L312-L317) and `lisp-mode.el` (Emacs bundled)