### PR TITLE
No need to index async-lambda

### DIFF
--- a/async-await.el
+++ b/async-await.el
@@ -233,12 +233,7 @@ See \"For complex cases\" section in `make-autoload'."
 (advice-add 'make-autoload :around #'async-await-advice-make-autoload)
 
 (add-to-list 'lisp-imenu-generic-expression
-             (list nil (purecopy (concat
-                                  "^\\s-*("
-                                  (eval-when-compile
-                                    (regexp-opt '("async-defun" "async-lambda") t))
-                                  "\\s-+\\(" lisp-mode-symbol-regexp "\\)"))
-                   2))
+             (list nil (concat "^\\s-*(async-defun\\s-+\\(" lisp-mode-symbol-regexp "\\)") 1))
 
 (provide 'async-await)
 ;;; async-await.el ends here


### PR DESCRIPTION
I made a mistake in #9 and mistakenly indexed `async-lambda`. `lambda` is not in `lisp-imenu-generic-expression` by default so I believe `async-lambda` should not be indexed. This PR fixes this mistake.